### PR TITLE
Only call NIC_validate on nic config files

### DIFF
--- a/network-environment-validator.py
+++ b/network-environment-validator.py
@@ -40,10 +40,11 @@ def main():
         #LOG.debug('\n' + yaml.dump(network_data))
 
     for item in network_data['resource_registry']:
-        data = network_data['resource_registry'][item]
-        #LOG.debug(data)
-        LOG.info('Validating %s', data)
-        NIC_validate(item, data)
+        if item.endswith("Net::SoftwareConfig"):
+            data = network_data['resource_registry'][item]
+            #LOG.debug(data)
+            LOG.info('Validating %s', data)
+            NIC_validate(item, data)
 
     for item in network_data['parameter_defaults']:
         data = network_data['parameter_defaults'][item]


### PR DESCRIPTION
The resource_registry can contain more than just NC mapping files. We only want to suitable lines into NIC_validate.
