### PR TITLE
fix erroneous tab in source

### DIFF
--- a/network-environment-validator.py
+++ b/network-environment-validator.py
@@ -99,7 +99,7 @@ def check_allocation_pools_pairing(filedata, pools):
             pooldata]
 
         subnet_item = poolitem.split('AllocationPools')[0] + 'NetCidr'
-	try:
+        try:
             subnet_obj = ipaddress.ip_network(
                 filedata[subnet_item].decode('utf-8'))
         except ValueError:


### PR DESCRIPTION
there was a tab in the source file where there should have been spaces
that was throwing off formatting and could have potentially caused
problems at some point in the future.
