### PR TITLE
use netaddr instead of ipaddress

### DIFF
--- a/network-environment-validator.py
+++ b/network-environment-validator.py
@@ -99,7 +99,7 @@ def check_allocation_pools_pairing(filedata, pools):
             pooldata]
 
         subnet_item = poolitem.split('AllocationPools')[0] + 'NetCidr'
-	try:
+        try:
             subnet_obj = ipaddress.ip_network(
                 filedata[subnet_item].decode('utf-8'))
         except ValueError:


### PR DESCRIPTION
the `ipaddress` module is only available by default in python3.  This
patches the network validator to use the `netaddr` module, which is already
used by other openstack projects, e.g...

```
# rpm -q --whatrequires python-netaddr
python-oslo-config-1.9.3-1.el7ost.noarch
python-oslo-utils-1.4.0-1.el7ost.noarch
python-keystoneclient-1.3.0-2.el7ost.noarch
python-hardware-0.14-6.el7ost.noarch
python-pycadf-0.8.0-1.el7ost.noarch
openstack-ironic-common-2015.1.0-9.el7ost.noarch
os-net-config-0.1.4-2.el7ost.noarch
python-saharaclient-0.9.0-1.el7ost.noarch
openstack-dashboard-2015.1.0-11.el7ost.noarch
openstack-tuskar-ui-0.3.0-15.el7ost.noarch
python-oslo-vmware-0.11.1-1.el7ost.noarch
python-nova-2015.1.0-18.el7ost.noarch
python-debtcollector-0.3.0-3.el7ost.noarch
python-glance-2015.1.0-7.el7ost.noarch
python-neutron-2015.1.0-16.el7ost.noarch
openstack-heat-common-2015.1.0-6.el7ost.noarch
python-ceilometer-2015.1.0-10.el7ost.noarch
python-keystone-2015.1.0-4.el7ost.noarch
openstack-tempest-kilo-20150708.2.el7ost.noarch
```

...so there is an excellent chance it will already be installed.
