### PR TITLE
Add the rogue DHCP validation

### DIFF
--- a/ansible-tests/validations/library/rogue_dhcp.py
+++ b/ansible-tests/validations/library/rogue_dhcp.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+
+DOCUMENTATION = '''
+---
+module: rogue_dhcp
+short_description: Detect rogue DHCP servers running on the specified networks.
+author: "Tomas Sedovic, @tomassedovic"
+requirements:
+- the "scapy" Python module
+options:
+  networks:
+    description:
+    - List of network ranges in CIDR notation to validate the discovered DHCP
+      servers against.
+    required: true
+  timeout_seconds:
+    description:
+    - The amount of time in seconds to wait for DHCP responses.
+    required: false
+    default: 30
+'''
+
+from ansible.module_utils.basic import *
+from scapy.all import *
+
+
+def find_dhcp_servers(timeout_sec):
+    conf.checkIPaddr = False
+    fam,hw = get_if_raw_hwaddr(conf.iface)
+    dhcp_discover = (Ether(dst="ff:ff:ff:ff:ff:ff")/
+                     IP(src="0.0.0.0",dst="255.255.255.255")/
+                     UDP(sport=68,dport=67)/
+                     BOOTP(chaddr=hw)/
+                     DHCP(options=[("message-type","discover"),"end"]))
+    ans, unans = srp(dhcp_discover, multi=True, timeout=timeout_sec)
+
+    return [(unicode(packet[1][IP].src), packet[1][Ether].src)
+            for packet in ans]
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            'networks': dict(required=True, type='list'),
+            'timeout_seconds': dict(default=30, type='int'),
+        }
+    )
+
+    # TODO: validate the specified networks against the discovered DHCP server
+    networks = module.params.get('networks')
+    if not networks:
+        module.exit_json(changed=False, msg='No networks were specified.')
+
+    dhcp_servers = find_dhcp_servers(module.params.get('timeout_seconds'))
+    if dhcp_servers:
+        formatted_servers = ("%s (%s)" % (ip, mac) for (ip, mac) in dhcp_servers)
+        results = "DHCP servers: %s\n\nNetworks: %s" % (
+            ','.join(formatted_servers), ','.join(networks))
+    else:
+        results = ""
+
+    result = {
+        'changed': True,
+        'msg': 'Found %d DHCP servers.' % len(dhcp_servers),
+        'results': results,
+    }
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible-tests/validations/rogue-dhcp.yaml
+++ b/ansible-tests/validations/rogue-dhcp.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: undercloud
+  vars:
+    metadata:
+      name: Rogue DHCP
+      description: Locate rogue DHCP servers on Pacemaker-managed networks
+    networks:  # TODO(shadower): read this from the overcloud setup
+    # NOTE(shadower): the values are ignored for now so it's okay they're bogus
+    - 10.10.1.1/24
+    - 10.10.2.1/24
+    - 10.10.3.1/24
+  tasks:
+  - name: Install scappy
+    yum: name=scapy state=present
+  - name: Look for a rogue DHCP
+    rogue_dhcp: networks="{{ networks }}" timeout_seconds=60


### PR DESCRIPTION
This adds a new validation that checks for DHCP responses on the
undercloud. Having a DHCP on a Pacemaker-managed network is a known
incompatibility.

Eventually, we will want to get a list of all the networks used for the
deployment and check for DHCP conflicts. In the meantime, this just
returns a list of discovered DHCP servers back.
