### PR TITLE
Implement connectivity check in bash

### DIFF
--- a/ansible-tests/validations/compute_node_connectivity.yaml
+++ b/ansible-tests/validations/compute_node_connectivity.yaml
@@ -3,24 +3,14 @@
   vars:
     metadata:
       name: Check connectivity of the compute nodes.
-    controller_ctlplane_ip_address: 'www.ansible.com'
-    controller_external_ip_address: 'www.ansible.com'
-    controller_internal_api_ip_address: 'www.ansible.com'
-    controller_storage_ip_address: 'www.ansible.com'
-    controller_storage_mgmt_ip_address: 'www.ansible.com'
-    controller_tenant_ip_address: 'www.ansible.com'
+
   tasks:
-  - name: Check controller IP address on the ctlplane network
-    icmp_ping: host="{{ controller_ctlplane_ip_address }}"
-  - name: Check controller IP address on the external network
-    icmp_ping: host="{{ controller_external_ip_address }}"
-  - name: Check controller IP address on the internal API network
-    icmp_ping: host="{{ controller_internal_api_ip_address }}"
-  - name: Check controller IP address on the storage network
-    icmp_ping: host="{{ controller_storage_ip_address }}"
-  - name: Check controller IP address on the storage mgmt network
-    icmp_ping: host="{{ controller_storage_mgmt_ip_address }}"
-  - name: Check controller IP address on the tenant network
-    icmp_ping: host="{{ controller_tenant_ip_address }}"
-  - name: Check default gateway
-    icmp_ping: host="{{ ansible_default_ipv4['gateway'] }}"
+  - name: Run ping test
+    script: "files/ping_nodes.sh
+      {{ controller_ctlplane_ip_address | default }}
+      {{ controller_external_ip_address | default }}
+      {{ controller_internal_api_ip_address | default }}
+      {{ controller_storage_ip_address | default }}
+      {{ controller_storage_mgmt_ip_address | default }}
+      {{ controller_tenant_ip_address | default }}"
+    changed_when: false

--- a/ansible-tests/validations/files/ping_nodes.sh
+++ b/ansible-tests/validations/files/ping_nodes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# For each unique remote IP (specified via Heat) we check to
+# see if one of the locally configured networks matches and if so we
+# attempt a ping test the remote network IP.
+function ping_controller_ips() {
+  local REMOTE_IPS=$@
+
+  for REMOTE_IP in $(echo $REMOTE_IPS | sed -e "s| |\n|g" | sort -u); do
+
+    for LOCAL_NETWORK in $(/usr/sbin/ip r | grep -v default | cut -d " " -f 1); do
+       local LOCAL_CIDR=$(echo $LOCAL_NETWORK | cut -d "/" -f 2)
+       local LOCAL_NETMASK=$(ipcalc -m $LOCAL_NETWORK | grep NETMASK | cut -d "=" -f 2)
+       local REMOTE_NETWORK=$(ipcalc -np $REMOTE_IP $LOCAL_NETMASK | grep NETWORK | cut -d "=" -f 2)
+
+       if [ $REMOTE_NETWORK/$LOCAL_CIDR == $LOCAL_NETWORK ]; then
+         echo -n "Trying to ping $REMOTE_IP for local network $LOCAL_NETWORK..."
+         if ! ping -c 1 $REMOTE_IP &> /dev/null; then
+           echo "FAILURE"
+           echo "$REMOTE_IP is not pingable. Local Network: $LOCAL_NETWORK" >&2
+           exit 1
+         fi
+         echo "SUCCESS"
+       fi
+    done
+  done
+}
+
+function ping_default_gateway() {
+  DEFAULT_GW=$(/usr/sbin/ip r | grep default | cut -d " " -f 3)
+  echo -n "Trying to ping default gateway ${DEFAULT_GW}..."
+  if ! ping -c 1 $DEFAULT_GW &> /dev/null; then
+    echo "FAILURE"
+    echo "$DEFAULT_GW is not pingable."
+    exit 1
+  fi
+  echo "SUCCESS"
+}
+
+ping_controller_ips "$@"
+ping_default_gateway


### PR DESCRIPTION
Re-use bash implementation available in tripleo-heat-templates.

Now the connectivity check is ignored for target IPs for which the node
doesn't have a route for.
