### PR TITLE
Temporarily disable the Discovery Diff validation

### DIFF
--- a/ansible-tests/stages/hardware-discovery.yaml
+++ b/ansible-tests/stages/hardware-discovery.yaml
@@ -5,6 +5,6 @@
       name: Hardware Discovery
       description: Validations that run after the hardware was discovered.
       stage: discovery
+#- include: ../validations/discovery_diff.yaml
 - include: ../validations/undercloud-disk-space.yaml
-- include: ../validations/discovery_diff.yaml
 - include: ../validations/512e.yaml


### PR DESCRIPTION
I can't seem to get it running right now and it seems to prevent all the
other validations from the "hardware-discovery" stage as well, so we're
disabling it for a moment.

It doesn't seem to be just a failing validation either -- that would let
the other ones run -- but something more severe.
