### PR TITLE
Add validation of the haproxy config

### DIFF
--- a/ansible-tests/validations/haproxy.yaml
+++ b/ansible-tests/validations/haproxy.yaml
@@ -1,0 +1,37 @@
+---
+- hosts: controller
+  vars:
+    metadata:
+      name: HAProxy configuration
+      description: todo
+    config_file: '/etc/haproxy/haproxy.cfg'
+    global_maxconn_min: 20480
+    defaults_maxconn_min: 4096
+    defaults_timeout_queue: '1m'
+    defaults_timeout_client: '1m'
+    defaults_timeout_server: '1m'
+    defaults_timeout_check: '10s'
+  tasks:
+  - name: Gather the HAProxy config
+    haproxy_conf: haproxy_conf_path="{{ config_file }}"
+  - name: Show loaded haproxy_conf
+    debug:
+      msg: "{{ haproxy_conf }}"
+  - name: Verify global maxconn
+    fail: msg="The 'global maxconn' value must be greater than {{ global_maxconn_min }}"
+    failed_when: "{{ haproxy_conf.global.maxconn}} < {{ global_maxconn_min }}"
+  - name: Verify defaults maxconn
+    fail: msg="The 'defaults maxconn' value must be greater than {{ defaults_maxconn_min }}"
+    failed_when: "{{ haproxy_conf.defaults.maxconn }} < {{ defaults_maxconn_min }}"
+  - name: Verify defaults timeout queue
+    fail: msg="The 'timeout queue' option in 'defaults' must be set to {{ defaults_timeout_queue }}"
+    failed_when: "'{{ haproxy_conf.defaults['timeout queue'] }}' != '{{ defaults_timeout_queue }}'"
+  - name: Verify defaults timeout client
+    fail: msg="The 'timeout client' option in 'defaults' must be set to {{ defaults_timeout_client }}"
+    failed_when: "'{{ haproxy_conf.defaults['timeout client'] }}' != '{{ defaults_timeout_client }}'"
+  - name: Verify defaults timeout server
+    fail: msg="The 'timeout server' option in 'defaults' must be set to {{ defaults_timeout_server }}"
+    failed_when: "'{{ haproxy_conf.defaults['timeout server'] }}' != '{{ defaults_timeout_server }}'"
+  - name: Verify defaults timeout check
+    fail: msg="The 'timeout check' option in 'defaults' must be set to {{ defaults_timeout_check }}"
+    failed_when: "'{{ haproxy_conf.defaults['timeout check'] }}' != '{{ defaults_timeout_check }}'"

--- a/ansible-tests/validations/library/haproxy_conf.py
+++ b/ansible-tests/validations/library/haproxy_conf.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import re
+
+from ansible.module_utils.basic import *
+
+
+# ConfigParser chokes on both mariadb and haproxy files. Luckily They have
+# a syntax approaching ini config file so they are relatively easy to parse.
+# This generic ini style config parser is not perfect -- it can ignore some
+# valid options --  but good enough for our use case.
+def generic_ini_style_conf_parser(file_path, section_regex, option_regex):
+    config = {}
+    current_section = None
+    with open(file_path) as config_file:
+        for line in config_file:
+            match_section = re.match(section_regex, line)
+            if match_section:
+                current_section = match_section.group(1)
+                config[current_section] = {}
+            match_option = re.match(option_regex, line)
+            if match_option and current_section:
+                option = re.sub('\s+', ' ', match_option.group(1))
+                config[current_section][option] = match_option.group(2)
+    return config
+
+
+def parse_haproxy_conf(file_path):
+    section_regex = '^(\w+)'
+    option_regex = '^(?:\s+)(\w+(?:\s+\w+)*?)\s+([\w/]*)$'
+    return generic_ini_style_conf_parser(file_path, section_regex, option_regex)
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        haproxy_conf_path=dict(required=True, type='str'),
+    ))
+
+    haproxy_conf_path = module.params.get('haproxy_conf_path')
+
+    try:
+        config = parse_haproxy_conf(haproxy_conf_path)
+    except IOError:
+        module.fail_json(msg="Could not open the haproxy conf file at: '%s'" %
+                         haproxy_conf_path)
+
+    module.exit_json(changed=False, ansible_facts={u'haproxy_conf': config})
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The parsing code and values taken from
`check_overcloud_controller_settings.py` in the root directory of this
repo.
