### PR TITLE
Fix the rogue dhcp validation

### DIFF
--- a/ansible-tests/validations/library/rogue_dhcp.py
+++ b/ansible-tests/validations/library/rogue_dhcp.py
@@ -54,8 +54,8 @@ def main():
     dhcp_servers = find_dhcp_servers(module.params.get('timeout_seconds'))
     if dhcp_servers:
         formatted_servers = ("%s (%s)" % (ip, mac) for (ip, mac) in dhcp_servers)
-        results = "DHCP servers: %s\n\nNetworks: %s" % (
-            ','.join(formatted_servers), ','.join(networks))
+        # TODO: write out the networks when we actually use them for anything:
+        results = "DHCP servers: %s" % ','.join(formatted_servers)
     else:
         results = ""
 

--- a/ansible-tests/validations/rogue-dhcp.yaml
+++ b/ansible-tests/validations/rogue-dhcp.yaml
@@ -1,5 +1,6 @@
 ---
 - hosts: undercloud
+  become: true
   vars:
     metadata:
       name: Rogue DHCP


### PR DESCRIPTION
We add `become: true` because it needs sudo on the undercloud and we
don't print the specified list of networks since it's not used for now.
