### PR TITLE
Fix scapy install

### DIFF
--- a/ansible-tests/validations/rogue-dhcp.yaml
+++ b/ansible-tests/validations/rogue-dhcp.yaml
@@ -11,6 +11,6 @@
     - 10.10.3.1/24
   tasks:
   - name: Install scappy
-    yum: name=scapy state=present
+    pip: name=scapy state=present
   - name: Look for a rogue DHCP
     rogue_dhcp: networks="{{ networks }}" timeout_seconds=60


### PR DESCRIPTION
On a fresh undercloud provisioned with tripleo-quickstart, the
rogue_dhcp validation fails with "No Package matching 'scapy' found
available, installed or updated" error.

We need to pip install scapy.
