### PR TITLE
.gitignore the Ansible .retry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ hosts
 .venv
 env_vars.json
 .tox
+*.retry


### PR DESCRIPTION
Ansible generates playbook-name.retry files. These clutter the git
status when the validations are run against the checkout.
