### PR TITLE
Rename hardware discovery group to pre-deployment

### DIFF
--- a/ansible-tests/stages/post-deployment.yaml
+++ b/ansible-tests/stages/post-deployment.yaml
@@ -10,3 +10,4 @@
 - include: ../validations/neutron-sanity-check.yaml
 - include: ../validations/mysql-open-files-limit.yaml
 - include: ../validations/check-openstack-endpoints.yaml
+- include: ../validations/no-op-firewall-nova-driver.yaml

--- a/ansible-tests/stages/pre-deployment.yaml
+++ b/ansible-tests/stages/pre-deployment.yaml
@@ -2,9 +2,9 @@
 - hosts: overcloud
   vars:
     metadata:
-      name: Hardware Discovery
-      description: Validations that run after the hardware was discovered.
-      stage: discovery
+      name: Pre-deployment
+      description: Validations that run before any deployment
+      stage: pre-deployment
 - include: ../validations/discovery_diff.yaml
 - include: ../validations/undercloud-disk-space.yaml
 - include: ../validations/undercloud-ram.yaml
@@ -13,3 +13,4 @@
 - include: ../validations/network_environment.yaml
 - include: ../validations/check-network-gateway.yaml
 - include: ../validations/instackenv.yaml
+- include: ../validations/rogue-dhcp.yaml

--- a/ansible-tests/validations/512e.yaml
+++ b/ansible-tests/validations/512e.yaml
@@ -7,7 +7,7 @@
         Detect whether the undercloud disks use Advanced Format. If they do,
         the overcloud images may fail to upload to Glance.
       groups:
-        - discovery
+        - pre-deployment
   tasks:
   - name: List the available drives
     register: drive_list

--- a/ansible-tests/validations/check-network-gateway.yaml
+++ b/ansible-tests/validations/check-network-gateway.yaml
@@ -7,7 +7,7 @@
         If `network_gateway` in `undercloud.conf` is different from `local_ip`,
         verify that the gateway exists and is reachable.
       groups:
-        - discovery
+        - pre-deployment
     undercloud_conf_path: "/home/stack/undercloud.conf"
   tasks:
   - name: Gather undercloud.conf values

--- a/ansible-tests/validations/discovery_diff.yaml
+++ b/ansible-tests/validations/discovery_diff.yaml
@@ -5,7 +5,7 @@
       name: Provide difference in hardware configuration
       description: This test provides difference in configuration based on data collected in ironic-inspector
       groups:
-        - discovery
+        - pre-deployment
   tasks:
   - name: Run the Discovery diff
     discovery_diff:

--- a/ansible-tests/validations/instackenv.yaml
+++ b/ansible-tests/validations/instackenv.yaml
@@ -11,7 +11,7 @@
         all the MAC and IPMI addresses are unique and in case the
         `ipmitool` is available, tries to connect to each node.
       groups:
-      - discovery
+      - pre-deployment
     instackenv_file_path: /home/stack/instackenv.json
   tasks:
   - name: Validate instackenv.json

--- a/ansible-tests/validations/network_environment.yaml
+++ b/ansible-tests/validations/network_environment.yaml
@@ -12,7 +12,7 @@
 
         http://tripleo.org/advanced_deployment/network_isolation.html
       groups:
-      - discovery
+        - pre-deployment
     network_environment_path: /home/stack/network-environment.yaml
   tasks:
   - name: Validate the network environment files

--- a/ansible-tests/validations/no-op-firewall-nova-driver.yaml
+++ b/ansible-tests/validations/no-op-firewall-nova-driver.yaml
@@ -6,6 +6,8 @@
       description: >
         When using Neutron, the `firewall_driver` option in Nova must be set to
         `NoopFirewallDriver`.
+      groups:
+        - post-deployment
   tasks:
   - name: Verify the `firewall_driver` value
     # TODO(shadower): if/when we have more validations that read a value from an

--- a/ansible-tests/validations/rogue-dhcp.yaml
+++ b/ansible-tests/validations/rogue-dhcp.yaml
@@ -5,6 +5,8 @@
     metadata:
       name: Rogue DHCP
       description: Locate rogue DHCP servers on Pacemaker-managed networks
+      groups:
+        - pre-deployment
     networks:  # TODO(shadower): read this from the overcloud setup
     # NOTE(shadower): the values are ignored for now so it's okay they're bogus
     - 10.10.1.1/24

--- a/ansible-tests/validations/undercloud-cpu.yaml
+++ b/ansible-tests/validations/undercloud-cpu.yaml
@@ -6,7 +6,7 @@
       description: >
         Make sure that the undercloud has enough CPU cores.
       groups:
-        - discovery
+        - pre-deployment
     # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux_OpenStack_Platform/7/html/Director_Installation_and_Usage/sect-Undercloud_Requirements.html
     undercloud_core_count: 8
   tasks:

--- a/ansible-tests/validations/undercloud-disk-space.yaml
+++ b/ansible-tests/validations/undercloud-disk-space.yaml
@@ -6,7 +6,7 @@
       description: >
         Make sure that the root partition on the undercloud node is large enough.
       groups:
-        - discovery
+        - pre-deployment
     # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux_OpenStack_Platform/7/html/Director_Installation_and_Usage/sect-Undercloud_Requirements.html
     minimum_disk_space_gb: 40
   tasks:

--- a/ansible-tests/validations/undercloud-ram.yaml
+++ b/ansible-tests/validations/undercloud-ram.yaml
@@ -7,6 +7,8 @@
         Make sure the undercloud has enough RAM.
 
         https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux_OpenStack_Platform/7/html/Director_Installation_and_Usage/sect-Undercloud_Requirements.html
+      groups:
+        - pre-deployment
     minimum_ram_gb: 16
   tasks:
   - name: Verify the RAM requirements


### PR DESCRIPTION
Because it better describes what this group is about, and hardware
discovery should be named introspection anyway.

Also add missing validations to proper groups.  Adding to both the
'stages' files and a group to support both the former validation API
PoC and the new mistral workflow.
