### PR TITLE
Start requiring Ansible 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,16 @@ us use these from the TripleO web UI and command line clients.
 For now, you need to run them manually. All the validations live in
 the [ansible-tests/validations](ansible-tests/validations) directory.
 
+**NOTE** We only support Ansible 2.0 and higher.
+
 To run a validation you need to:
 
     $ git clone https://github.com/rthallisey/clapper.git
     $ source ~/stackrc
     $ cd clapper/ansible-tests
     $ ls validations  # pick a validation to run
-    $ ansible-playbook -v -i tripleo-ansible-inventory.py validations/some_validation.yaml
+    $ ansible-playbook -i tripleo-ansible-inventory.py validations/some_validation.yaml
 
-NOTE: some validations only produce useful output when run with a
-higher verbosity (the `-v` switch). You should check it even when the
-validations are passing.
-
-When we integrate with TripleO via an API, these results will be
-reported in a more visible manner (e.g. show up as warnings).
 
 
 ### Contributing validations or ideas

--- a/ansible-tests/mistral/README.md
+++ b/ansible-tests/mistral/README.md
@@ -18,10 +18,7 @@ mistral_executor running with:
 
 You also need to have ansible installed on the undercloud:
 
-    $ sudo pip install 'ansible<2'
-
-The validation playbooks have only been tested with ansible 1.9.4 at the
-moment.
+    $ sudo pip install 'ansible>=2'
 
 Finaly, make sure `sudo` can run without the need for a tty. In `/etc/sudoers`
 comment out the line "Defaults requiretty" if it's set.

--- a/ansible-tests/requirements.txt
+++ b/ansible-tests/requirements.txt
@@ -1,4 +1,4 @@
-ansible==1.9.4
+ansible>=2.0
 Babel==2.2.0
 debtcollector==1.2.0
 ecdsa==0.13
@@ -6,6 +6,7 @@ Flask==0.10.1
 Flask-Cors==2.1.2
 funcsigs==0.4
 futures==3.0.3
+ipaddress==1.0.16
 iso8601==0.1.11
 itsdangerous==0.24
 Jinja2==2.8

--- a/ansible-tests/validations/check_openstack_endpoints.yaml
+++ b/ansible-tests/validations/check_openstack_endpoints.yaml
@@ -22,12 +22,13 @@
     uri:
       url: "{{ overcloudrc.OS_AUTH_URL }}/tokens"
       method: POST
-      headers:
-        "Content-Type": "application/json"
-      # NOTE(shadower): this is a workaround for a bug in Ansible 1.9. When
-      # we switch to 2.x only, we can replace this with a yaml dict.
-      # Yes. The space character at the beginning is apparently necessary here.
-      body: ' {"auth": {"passwordCredentials": {"username": "{{ overcloudrc.OS_USERNAME }}", "password": "{{ overcloudrc.OS_PASSWORD }}"}, "tenantName": "{{ overcloudrc.OS_TENANT_NAME }}"} }'
+      body_format: json
+      body:
+        auth:
+          passwordCredentials:
+            username: "{{ overcloudrc.OS_USERNAME }}"
+            password: "{{ overcloudrc.OS_PASSWORD }}"
+          tenantName: "{{ overcloudrc.OS_TENANT_NAME }}"
       return_content: yes
     register: auth_token
 

--- a/ansible-tests/validations/mysql-open-files-limit.yaml
+++ b/ansible-tests/validations/mysql-open-files-limit.yaml
@@ -12,11 +12,11 @@
     min_open_files_limit: 16384
   tasks:
   - name: Get the open_files_limit value
-    mysql_variables: variable=open_files_limit
+    mysql_variables: variable=open_files_limit login_user=root login_password="" login_host=localhost
     register: mysqld_open_files_limit
   - name: Test the open-files-limit value
     fail:
       msg: >
         The open_files_limit option for mysql must be higher than
-        {{ min_open_files_limit }}. Right now it's {{ mysqld_open_files_limit.msg.0.1 }}.
-    failed_when: "{{ mysqld_open_files_limit.msg.0.1|int }} < {{ min_open_files_limit }}"
+        {{ min_open_files_limit }}. Right now it's {{ mysqld_open_files_limit.msg }}.
+    failed_when: "{{ mysqld_open_files_limit.msg|int }} < {{ min_open_files_limit }}"


### PR DESCRIPTION
This updates a couple of validations to Ansible 2 and makes it clear it's the default in the docs.
