### PR TITLE
Add new network environment checks

### DIFF
--- a/testing/static-ip-conflict-with-pool.yaml
+++ b/testing/static-ip-conflict-with-pool.yaml
@@ -62,6 +62,7 @@ parameter_defaults:
   ComputeIPs:
     internal_api:
     - 10.35.191.100
+    - 10.35.191.100    # ERROR: Duplicate with the line above
     - 10.35.191.110
     - 10.35.191.120
     storage:
@@ -77,4 +78,4 @@ parameter_defaults:
     storage_mgmt:
     - 192.168.150.20   # ERROR: duplicate of ControllerIPs.storage_mgmt
     - 192.168.150.90
-    - 10.35.191.120    # ERROR: duplicate of ComputeIPs.internal_api; outside of CIDR
+    - 10.35.191.120    # 2 ERRORS: duplicate of ComputeIPs.internal_api and outside of CIDR

--- a/testing/static-ip-conflict-with-pool.yaml
+++ b/testing/static-ip-conflict-with-pool.yaml
@@ -73,8 +73,8 @@ parameter_defaults:
     storage:
     - 192.168.100.70
     - 192.168.100.80
-    - 192.168.100.90
+    - 192.168.113.90   # ERROR: it's outside of StorageNetCidr (192.168.100.0/24)
     storage_mgmt:
-    - 192.168.150.80
+    - 192.168.150.20   # ERROR: duplicate of ControllerIPs.storage_mgmt
     - 192.168.150.90
-    - 192.168.150.99
+    - 10.35.191.120    # ERROR: duplicate of ComputeIPs.internal_api; outside of CIDR


### PR DESCRIPTION
This updates the network-environment validations with two new checks. The first one verifies the static IP addresses belong to the corresponding CIDR and the second one makes sure that there are no duplicate IPs. The test file is updated to show both errors.
