### PR TITLE
Add additional files to neutron-sanity-check

### DIFF
--- a/ansible-tests/validations/files/neutron-sanity-check
+++ b/ansible-tests/validations/files/neutron-sanity-check
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+ARGS=
+
+for config_file in $1; do
+    if [ -f "$config_file" ]; then
+        ARGS="$ARGS --config-file $config_file"
+    fi
+done
+
+for config_dir in $2; do
+    if [ -d "$config_dir" ]; then
+        ARGS="$ARGS --config-dir $config_dir"
+    fi
+done
+
+set -x
+
+neutron-sanity-check $ARGS

--- a/ansible-tests/validations/neutron-sanity-check.yaml
+++ b/ansible-tests/validations/neutron-sanity-check.yaml
@@ -8,6 +8,33 @@
         Neutron's configuration.
       groups:
         - post-deployment
+    config_files:
+    - /etc/neutron/neutron.conf
+    - /usr/share/neutron/neutron-dist.conf
+    - /etc/neutron/metadata_agent.ini
+    - /etc/neutron/metering_agent.ini
+    - /etc/neutron/dhcp_agent.ini
+    - /etc/neutron/plugins/ml2/openvswitch_agent.ini
+    - /etc/neutron/conf.d/ml2_conf_cisco.ini
+    - /etc/neutron/conf.d/cisco_cfg_agent.ini
+    - /etc/neutron/conf.d/cisco_router_plugin.ini
+    - /etc/neutron/dhcp_agent.ini
+    config_dirs:
+    - /usr/share/neutron/l3_agent
+    - /etc/neutron/conf.d/common
+    - /etc/neutron/conf.d/neutron-l3-agent
+    - /usr/share/neutron/neutron-lbaas-dist.conf
+    - /etc/neutron/lbaas_agent.ini
+    - /etc/neutron/conf.d/neutron-lbaas-agent
+    - /etc/neutron/conf.d/neutron-lbaasv2-agent
+    - /etc/neutron/conf.d/neutron-metadata-agent
+    - /etc/neutron/conf.d/neutron-metering-agent
+    - /etc/neutron/conf.d/neutron-netns-cleanup
+    - /etc/neutron/conf.d/neutron-openvswitch-agent
+    - /etc/neutron/conf.d/neutron-ovs-cleanup
+    - /etc/neutron/conf.d/neutron-bsn-agent
+    - /etc/neutron/conf.d/neutron-cisco-cfg-agent
+    - /etc/neutron/conf.d/neutron-dhcp-agent
   tasks:
   - name: Run neutron-sanity-check
-    command: neutron-sanity-check --config-file /etc/neutron/neutron.conf
+    script: files/neutron-sanity-check '"{{config_files|join(" ")}}" "{{config_dirs|join(" ")}}"'


### PR DESCRIPTION
neutron-sanity-check expects to be passed all the --config-file/--config-dir
options the Neutron services receive.

Unfortunately, when we pass in a file/directory that doesn't exist, the script
crashes. So we're building the list of existing files/dirs in a shell script
and pass only the ones they're present.

We could do the same in Ansible, but that would generate a lot of duplicate
output and be more confusing to the users.
