### PR TITLE
Update the Discovery Diff validation for ansible1.9

### DIFF
--- a/ansible-tests/validations/discovery_diff.yaml
+++ b/ansible-tests/validations/discovery_diff.yaml
@@ -6,6 +6,13 @@
       description: This test provides difference in configuration based on data collected in ironic-inspector
       groups:
         - pre-deployment
+    undercloud_conf_path: ~/undercloud-passwords.conf
   tasks:
+  - name: Load introspection password from undercloud.conf
+    lookup_ini: option=undercloud_ironic_password section=auth file={{ undercloud_conf_path }}
+    register: introspection_password
   - name: Run the Discovery diff
     discovery_diff:
+      os_tenant_name: service
+      os_username: ironic
+      os_password: "{{ introspection_password.value }}"

--- a/ansible-tests/validations/library/lookup_ini.py
+++ b/ansible-tests/validations/library/lookup_ini.py
@@ -23,7 +23,7 @@ def main():
 
         result = config.get(section, option)
 
-        module.exit_json(changed=False, ansible_facts={u'value': result})
+        module.exit_json(changed=False, value=result)
     else:
         module.fail_json(msg="Could not open the '%s' file"
                          % undercloud_conf_path)

--- a/ansible-tests/validations/library/lookup_ini.py
+++ b/ansible-tests/validations/library/lookup_ini.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import ConfigParser
+from os import path
+
+from ansible.module_utils.basic import *
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        option=dict(required=True, type='str'),
+        section=dict(required=True, type='str'),
+        file=dict(required=True, type='str'),
+    ))
+
+    option = module.params.get('option')
+    section = module.params.get('section')
+    ini_path = path.expanduser(module.params.get('file'))
+
+    if path.exists(ini_path) and path.isfile(ini_path):
+        config = ConfigParser.SafeConfigParser()
+        config.read(ini_path)
+
+        result = config.get(section, option)
+
+        module.exit_json(changed=False, ansible_facts={u'value': result})
+    else:
+        module.fail_json(msg="Could not open the '%s' file"
+                         % undercloud_conf_path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The updates to Discovery Diff weren't backported to the `ansible1.9` branch, because they weren't compatible with 1.9. Unfortunately, the version that does not work out of the box, which will make it broken for the use with the UI.

So this ports the discovery_diff library code over and creates a workaround for reading the ini contents for Ansible 1.9.
