### PR TITLE
Fixing README as host bits should not be set in commands

### DIFF
--- a/dhcp-test/README.md
+++ b/dhcp-test/README.md
@@ -24,8 +24,8 @@ running Keystone.
 If you run `dhcp-test.sh`, it will install the dependencies, run the
 test script and remove the deps again:
 
-    # ./dhcp-test.sh -p 10.15.20.0/16 -p 10.15.32.0/16
+    # ./dhcp-test.sh -p 10.15.20.0 -p 10.15.32.0
 
 If you install the dependencies yourself, you can run the test script directly:
 
-    # python test-pacemaker-networks.py 10.15.20.0/16 10.15.32.0/16
+    # python test-pacemaker-networks.py 10.15.20.0 10.15.32.0


### PR DESCRIPTION
While trying to get this running I was getting the below error from both the commands

WARNING: No route found for IPv6 destination :: (no default route?)
Traceback (most recent call last):
  File "test-pacemaker-networks.py", line 25, in <module>
    for net in sys.argv[1:]]
  File "/home/stack/clapper/dhcp-test/.venv/lib/python2.7/site-packages/ipaddress.py", line 186, in ip_network
    return IPv4Network(address, strict)
  File "/home/stack/clapper/dhcp-test/.venv/lib/python2.7/site-packages/ipaddress.py", line 1656, in **init**
    raise ValueError('%s has host bits set' % self)
ValueError: 10.15.20.0/16 has host bits set
