### PR TITLE
Add undercloud debug logging check

### DIFF
--- a/ansible-tests/validations/README.md
+++ b/ansible-tests/validations/README.md
@@ -36,6 +36,7 @@ Validations can belong to multiple groups.
 * [Validate the Heat network environment files](network_environment.yaml)
 * [Detect rogue DHCP servers](rogue-dhcp.yaml)
 * [Verify the undercloud doesn't run too many processes](undercloud-process-count.yaml)
+* [Verify debug is disabled on undercloud services](undercloud-debug.yaml)
 
 ## Post-deployment ##
 

--- a/ansible-tests/validations/undercloud-debug.yaml
+++ b/ansible-tests/validations/undercloud-debug.yaml
@@ -1,0 +1,22 @@
+---
+- hosts: undercloud
+  vars:
+    metadata:
+      name: Undercloud Services Debug Check
+      description: >
+        The undercloud's openstack services should _not_ have debug enabled.This will check if debug is enabled on undercloud services.  If debug is enabled, the root filesystem can fill up quickly, and is not a good thing.
+      groups:
+        - pre-deployment
+    debug_check: "debug.*=.*True"
+  tasks:
+  - name: Check the services for debug flag
+    become: true
+    command: grep -i {{ debug_check }} {{ item }}
+    register: grep_result
+    with_items:
+      - /etc/nova/nova.conf
+      - /etc/neutron/neutron.conf
+      - /etc/ceilometer/ceilometer.conf
+      - /etc/heat/heat.conf
+      - /etc/ironic/ironic.conf
+    failed_when: "grep_result.rc != 1"


### PR DESCRIPTION
This is a check to ensure debug is not enabled on all undercloud services.
We've had issues with customers getting their root volumes filled on their undercloud due to debug being enabled.
