### PR TITLE
Add the missing coma to ipmitool invocation

### DIFF
--- a/ansible-tests/validations/library/validate_instackenv.py
+++ b/ansible-tests/validations/library/validate_instackenv.py
@@ -21,7 +21,7 @@ def contact_node(address, username, password):
     '''
     cmd = ['ipmitool', '-R', '1', '-I', 'lanplus',
            '-H', address, '-U', username, '-P', password,
-           'chassis' 'status']
+           'chassis', 'status']
     try:
         status = subprocess.call(cmd)
         return status == 0


### PR DESCRIPTION
The instackenv validation's ipmitool check was failing because the
missing coma caused the last two parameters to be concatenated and
result in an incorrect invocation.
