### PR TITLE
Fix the Pacemaker validation under Ansible 1.9

### DIFF
--- a/ansible-tests/validations/library/pacemaker.py
+++ b/ansible-tests/validations/library/pacemaker.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+
+import base64
 import itertools
 from subprocess import Popen, PIPE
 from xml.etree import ElementTree
@@ -28,7 +31,7 @@ def main():
         status=dict(required=True, type='str'),
     ))
 
-    pcs_status = parse_pcs_status(module.params.get('status'))
+    pcs_status = parse_pcs_status(base64.b64decode(module.params.get('status')))
     failures = pcs_status['failures']
     failed = len(failures) > 0
     if failed:

--- a/ansible-tests/validations/pacemaker-status.yaml
+++ b/ansible-tests/validations/pacemaker-status.yaml
@@ -16,4 +16,4 @@
     command: pcs status xml
     register: pcs_status
   - name: Check pacemaker status
-    pacemaker: status="{{ pcs_status.stdout }}"
+    pacemaker: status="{{ pcs_status.stdout| b64encode }}"


### PR DESCRIPTION
There's a bug in Ansible 1.9 where passing some XML content between
tasks or modules like we do here breaks. Running this validation could
result in failing with this error:

```
a duplicate parameter was found in the argument string (2016" exec-time)
```

The error happened while running the "pacemaker" custom module, but was
present even when I removed everything but the module setup code.

This seems to be fixed in Ansible 2.0, but for 1.9, encoding the
pacemaker output in base64 fixes the problem.
